### PR TITLE
fix(init): Stack ID in Python init template doesn't match other languages

### DIFF
--- a/packages/aws-cdk/lib/init-templates/v1/app/python/app.template.py
+++ b/packages/aws-cdk/lib/init-templates/v1/app/python/app.template.py
@@ -6,6 +6,6 @@ from %name.PythonModule%.%name.PythonModule%_stack import %name.PascalCased%Stac
 
 
 app = core.App()
-%name.PascalCased%Stack(app, "%name.StackName%")
+%name.PascalCased%Stack(app, "%name.PascalCased%Stack")
 
 app.synth()

--- a/packages/aws-cdk/lib/init-templates/v2/app/python/app.template.py
+++ b/packages/aws-cdk/lib/init-templates/v2/app/python/app.template.py
@@ -6,6 +6,6 @@ from %name.PythonModule%.%name.PythonModule%_stack import %name.PascalCased%Stac
 
 
 app = core.App()
-%name.PascalCased%Stack(app, "%name.StackName%")
+%name.PascalCased%Stack(app, "%name.PascalCased%Stack")
 
 app.synth()


### PR DESCRIPTION
In all other languages other than Python, creating a new folder `hello-cdk` and doing `cdk init` results in a stack with an ID of `HelloCdkStack`. In Python you get `hello-cdk`.

This PR changes the Python init template to match the other languages.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
