### PR TITLE
(cli) add npm command to new version notice

### DIFF
--- a/packages/aws-cdk/lib/version.ts
+++ b/packages/aws-cdk/lib/version.ts
@@ -108,7 +108,7 @@ export async function displayVersionMessage(): Promise<void> {
     if (laterVersion) {
       const bannerMsg = formatAsBanner([
         `Newer version of CDK is available [${colors.green(laterVersion as string)}]`,
-        'Upgrade recommended',
+        'Upgrade recommended (npm install -g aws-cdk)',
       ]);
       bannerMsg.forEach((e) => print(e));
     }


### PR DESCRIPTION
A colleague had to go look up the `npm` command to update the CDK. This is probably common with Python, Java, C#, and Go developers who don't work with NPM on a daily basis.

Put the necessary command right in the upgrade notice.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
