### PR TITLE
docs(aws-glue): catalogID property of the Database class should be described as AWS account ID

### DIFF
--- a/packages/@aws-cdk/aws-glue/lib/database.ts
+++ b/packages/@aws-cdk/aws-glue/lib/database.ts
@@ -67,7 +67,7 @@ export class Database extends Resource implements IDatabase {
   public readonly catalogArn: string;
 
   /**
-   * ID of the Glue catalog in which this database is stored.
+   * The catalog id of the database (usually, the AWS account id).
    */
   public readonly catalogId: string;
 


### PR DESCRIPTION
In response to a support request from a customer, updating the description for the catalogID property to mention it is usually the AWS account ID, using the same wording used to describe the property on the corresponding properties interface.
